### PR TITLE
ESNext 03 - Editable Block Template

### DIFF
--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -63,6 +63,34 @@ const templates = {
 		],
 		wpScriptsEnabled: true,
 	},
+	esnextEditable: {
+		defaultValues: {
+			namespace,
+			slug: 'esnext-editable',
+			title: 'ESNext Editable Example',
+			description:
+				'Example of editable block – build step required.',
+			dashicon,
+			category,
+			author,
+			license,
+			licenseURI,
+			version,
+		},
+		outputFiles: [
+			'.editorconfig',
+			'.gitignore',
+			'editor.css',
+			'src/edit.js',
+			'src/index.js',
+			'src/save.js',
+			'$slug.php',
+			'style.css',
+			'readme.txt',
+		],
+		wpScriptsEnabled: true,
+
+	}
 };
 
 const getTemplate = ( templateName ) => {

--- a/packages/create-block/lib/templates/esnextEditable/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/$slug.php.mustache
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Plugin Name:     {{title}}
+{{#description}}
+ * Description:     {{description}}
+{{/description}}
+ * Version:         {{version}}
+{{#author}}
+ * Author:          {{author}}
+{{/author}}
+{{#license}}
+ * License:         {{license}}
+{{/license}}
+{{#licenseURI}}
+ * License URI:     {{{licenseURI}}}
+{{/licenseURI}}
+ * Text Domain:     {{textdomain}}
+ *
+ * @package         {{namespace}}
+ */
+
+/**
+ * Registers all block assets so that they can be enqueued through the block editor
+ * in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/block-editor/tutorials/block-tutorial/applying-styles-with-stylesheets/
+ */
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	$dir = dirname( __FILE__ );
+
+	$script_asset_path = "$dir/build/index.asset.php";
+	if ( ! file_exists( $script_asset_path ) ) {
+		throw new Error(
+			'You need to run `npm start` or `npm run build` for the "{{namespace}}/{{slug}}" block first.'
+		);
+	}
+	$index_js     = 'build/index.js';
+	$script_asset = require( $script_asset_path );
+	wp_register_script(
+		'{{namespace}}-{{slug}}-block-editor',
+		plugins_url( $index_js, __FILE__ ),
+		$script_asset['dependencies'],
+		$script_asset['version']
+	);
+
+	$editor_css = 'editor.css';
+	wp_register_style(
+		'{{namespace}}-{{slug}}-block-editor',
+		plugins_url( $editor_css, __FILE__ ),
+		array(),
+		filemtime( "$dir/$editor_css" )
+	);
+
+	$style_css = 'style.css';
+	wp_register_style(
+		'{{namespace}}-{{slug}}-block',
+		plugins_url( $style_css, __FILE__ ),
+		array(),
+		filemtime( "$dir/$style_css" )
+	);
+
+	register_block_type( '{{namespace}}/{{slug}}', array(
+		'editor_script' => '{{namespace}}-{{slug}}-block-editor',
+		'editor_style'  => '{{namespace}}-{{slug}}-block-editor',
+		'style'         => '{{namespace}}-{{slug}}-block',
+	) );
+}
+add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );

--- a/packages/create-block/lib/templates/esnextEditable/.editorconfig.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/.editorconfig.mustache
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-block/lib/templates/esnextEditable/.gitignore.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/.gitignore.mustache
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Output of 'npm pack'
+*.tgz
+
+# dotenv environment variables file
+.env

--- a/packages/create-block/lib/templates/esnextEditable/editor.css.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/editor.css.mustache
@@ -1,0 +1,12 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-{{namespace}}-{{slug}} {
+	color: green;
+	background: #cfc;
+	border: 2px solid #9c9;
+	padding: 20px;
+}

--- a/packages/create-block/lib/templates/esnextEditable/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/readme.txt.mustache
@@ -1,0 +1,63 @@
+=== {{title}} ===
+{{#author}}
+Contributors:      {{author}}
+{{/author}}
+Tags:              block
+Requires at least: 5.3.2
+Tested up to:      5.3.2
+Stable tag:        {{version}}
+Requires PHP:      7.0.0
+{{#license}}
+License:           {{license}}
+{{/license}}
+{{#licenseURI}}
+License URI:       {{{licenseURI}}}
+{{/licenseURI}}
+
+{{description}}
+
+== Description ==
+
+This is the long description. No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload the plugin files to the `/wp-content/plugins/{{slug}}` directory, or install the plugin through the WordPress plugins screen directly.
+1. Activate the plugin through the 'Plugins' screen in WordPress
+
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
+== Changelog ==
+
+= {{version}} =
+* Release
+
+== Arbitrary section ==
+
+You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation." Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/create-block/lib/templates/esnextEditable/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/edit.js.mustache
@@ -1,0 +1,36 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+
+ /* @see https://developer.wordpress.org/block-editor/developers/richtext/
+ */
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
+ *
+ * @param {Object} [props] Properties passed from the editor.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit( { attributes, setAttributes, className } ) {
+
+		const onChangeContent = ( newContent ) => {
+			setAttributes( { content: newContent } );
+		};
+		return (
+			<RichText
+				tagName="p"
+				className={ className }
+				onChange={ onChangeContent }
+				value={ content }
+			/>
+		);
+}

--- a/packages/create-block/lib/templates/esnextEditable/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/edit.js.mustache
@@ -20,7 +20,13 @@ import { RichText } from '@wordpress/block-editor';
  *
  * @return {WPElement} Element to render.
  */
-export default function Edit( { attributes, setAttributes, className } ) {
+export default function Edit( props ) {
+
+		const {
+			attributes: { content },
+			setAttributes,
+			className,
+		} = props;
 
 		const onChangeContent = ( newContent ) => {
 			setAttributes( { content: newContent } );

--- a/packages/create-block/lib/templates/esnextEditable/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/index.js.mustache
@@ -1,0 +1,94 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+
+import { RichText } from '@wordpress/block-editor';
+
+
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import Save from './save';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+registerBlockType( '{{namespace}}/{{slug}}', {
+	/**
+	 * This is the display title for your block, which can be translated with `i18n` functions.
+	 * The block inserter will show this name.
+	 */
+	title: __(
+		'{{title}}',
+		'{{textdomain}}'
+	),
+
+	{{#description}}
+	/**
+	 * This is a short description for your block, can be translated with `i18n` functions.
+	 * It will be shown in the Block Tab in the Settings Sidebar.
+	 */
+	description: __(
+		'{{description}}',
+		'{{textdomain}}'
+	),
+
+	{{/description}}
+	/**
+	 * Blocks are grouped into categories to help users browse and discover them.
+	 * The categories provided by core are `common`, `embed`, `formatting`, `layout` and `widgets`.
+	 */
+	category: '{{category}}',
+
+	{{#dashicon}}
+	/**
+	 * An icon property should be specified to make it easier to identify a block.
+	 * These can be any of WordPress’ Dashicons, or a custom svg element.
+	 */
+	icon: '{{dashicon}}',
+
+	{{/dashicon}}
+	/**
+	 * Optional block extended support features.
+	 */
+	supports: {
+		// Removes support for an HTML mode.
+		html: false,
+	},
+	attributes: {
+		content: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
+		},
+	},
+	example: {
+		attributes: {
+			content: __( 'Hello world' ),
+		},
+	},
+
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+
+	/**
+	 * @see ./save.js
+	 */
+	save: Save,
+} );

--- a/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
@@ -1,0 +1,23 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+ /* @see https://developer.wordpress.org/block-editor/developers/richtext/
+ */
+import { RichText } from '@wordpress/block-editor';
+/**
+ * The save function defines the way in which the different attributes should
+ * be combined into the final markup, which is then serialized by the block
+ * editor into `post_content`.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Save( { attributes } ) {
+	return (
+			<RichText.Content tagName="p" value={ props.attributes.content } />
+		);
+}

--- a/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
@@ -16,8 +16,8 @@ import { RichText } from '@wordpress/block-editor';
  *
  * @return {WPElement} Element to render.
  */
-export default function Save( { attributes } ) {
+export default function Save( props ) {
 	return (
-			<RichText.Content tagName="p" value={ attributes.content } />
+			<RichText.Content tagName="p" value={ props.attributes.content } />
 		);
 }

--- a/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/src/save.js.mustache
@@ -18,6 +18,6 @@ import { RichText } from '@wordpress/block-editor';
  */
 export default function Save( { attributes } ) {
 	return (
-			<RichText.Content tagName="p" value={ props.attributes.content } />
+			<RichText.Content tagName="p" value={ attributes.content } />
 		);
 }

--- a/packages/create-block/lib/templates/esnextEditable/style.css.mustache
+++ b/packages/create-block/lib/templates/esnextEditable/style.css.mustache
@@ -1,0 +1,13 @@
+/**
+ * The following styles get applied both on the front of your site
+ * and in the editor.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-{{namespace}}-{{slug}} {
+	color: darkred;
+	background: #fcc;
+	border: 2px solid #c99;
+	padding: 20px;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Converting the Gutenberg Example 03 - ESNEXT Editable Block to a template on the create-block package. 

## How has this been tested?
Once the template was created, the create-block package was used to make a block plugin with the template. The plugin was tested on a local instance of WP

## Types of changes
This is an enhancement of the available templates on the create-block package. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
